### PR TITLE
fix: report Twilio message delivery failures

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2017-2025 Splunk Inc.
+   Copyright (c) 2017-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: Twilio
-Copyright (c) 2017-2025 Splunk Inc.
+Copyright (c) 2017-2026 Splunk Inc.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Twilio
 
-Publisher: Splunk \
-Connector Version: 2.0.5 \
-Product Vendor: Twilio \
-Product Name: Twilio \
+Publisher: Splunk <br>
+Connector Version: 2.0.5 <br>
+Product Vendor: Twilio <br>
+Product Name: Twilio <br>
 Minimum Product Version: 4.9.39220
 
 This app integrates with Twilio for sending messages
@@ -22,14 +22,14 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration \
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration <br>
 [send message](#action-send-message) - Send an SMS Text
 
 ## action: 'test connectivity'
 
 Validate the asset configuration for connectivity using supplied configuration
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -44,7 +44,7 @@ No Output
 
 Send an SMS Text
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 Sends an SMS text to the specified Phone number.
@@ -97,7 +97,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2017-2025 Splunk Inc.
+# Copyright (c) 2017-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* - Return an error when Twilio reports failed or undelivered delivery status, or delivery remains unconfirmed at the polling timeout.
+* Return an error when Twilio reports failed or undelivered delivery status, or delivery remains unconfirmed at the polling timeout.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+- Return an error when Twilio reports failed or undelivered delivery status, or delivery remains unconfirmed at the polling timeout.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-- Return an error when Twilio reports failed or undelivered delivery status, or delivery remains unconfirmed at the polling timeout.
+* - Return an error when Twilio reports failed or undelivered delivery status, or delivery remains unconfirmed at the polling timeout.

--- a/twilio.json
+++ b/twilio.json
@@ -318,5 +318,11 @@
             },
             "versions": "EQ(*)"
         }
-    ]
+    ],
+    "pip39_dependencies": {
+        "wheel": []
+    },
+    "pip313_dependencies": {
+        "wheel": []
+    }
 }

--- a/twilio.json
+++ b/twilio.json
@@ -9,7 +9,7 @@
     "product_name": "Twilio",
     "product_version_regex": ".*",
     "publisher": "Splunk",
-    "license": "Copyright (c) 2017-2025 Splunk Inc.",
+    "license": "Copyright (c) 2017-2026 Splunk Inc.",
     "fips_compliant": false,
     "app_version": "2.0.5",
     "utctime_updated": "2025-08-01T20:40:54.323904Z",

--- a/twilio_connector.py
+++ b/twilio_connector.py
@@ -1,6 +1,6 @@
 # File: twilio_connector.py
 #
-# Copyright (c) 2017-2025 Splunk Inc.
+# Copyright (c) 2017-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/twilio_connector.py
+++ b/twilio_connector.py
@@ -196,11 +196,20 @@ class TwilioConnector(BaseConnector):
                 return RetVal(action_result.set_status(phantom.APP_ERROR, "Status key not part of the response"), None)
 
             if status in consts.TWILIO_FINAL_STATUS:
-                break
+                if status == "delivered":
+                    return RetVal(phantom.APP_SUCCESS, response)
+
+                message = f"Message delivery failed with status: {status}"
+                if response.get("error_code") is not None:
+                    message += f", error code: {response['error_code']}"
+                if response.get("error_message"):
+                    message += f", error message: {response['error_message']}"
+                return RetVal(action_result.set_status(phantom.APP_ERROR, message), response)
 
             time.sleep(consts.TWILIO_SLEEP_SECS)
 
-        return RetVal(phantom.APP_SUCCESS, response)
+        message = f"Message delivery was not confirmed within {timeout} minute(s) for SID: {message_id}"
+        return RetVal(action_result.set_status(phantom.APP_ERROR, message), response)
 
     def _send_text(self, action_result, body, to_phone):
         data = {"Body": body, "To": to_phone, "From": self._from_phone}

--- a/twilio_consts.py
+++ b/twilio_consts.py
@@ -1,6 +1,6 @@
 # File: twilio_consts.py
 #
-# Copyright (c) 2017-2025 Splunk Inc.
+# Copyright (c) 2017-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary

- Return an action error when Twilio reports failed or undelivered message delivery status.
- Return an action error with the message SID when delivery remains unconfirmed after the existing polling budget.
- Retain exact generated pip39/pip313 dependency sections; this connector declares no dependencies.

## Tracking

- PAPP-38092
- PSAAS-32440 (VULN-95163, FS-3686)

## Source

- Twilio Message Resource status and error-field semantics: https://www.twilio.com/docs/messaging/api/message-resource

## Validation

- Focused polling-control-flow test for failed, delivered, and timed-out responses.
- `python3 -m py_compile twilio_connector.py twilio_consts.py`
- `jq empty twilio.json` and `git diff --check`
- Full Docker-backed package gate with Python 3.13 and `PRE_COMMIT_HOME=/tmp/codex-precommit-twilio-psaas32440`

Written by Codex.