### PR TITLE
fix: keep Twilio connectivity test read-only

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.42.1
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.8
     hooks:
       - id: build-docs
         language: python

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 **account_sid** | required | string | Account SID |
 **auth_token** | required | password | Auth Token |
 **from_phone** | required | string | From Phone Number (Twilio Assigned, e.g. +15101281337) |
-**to_phone** | optional | string | To Phone Number (Used only for test connectivity) |
+**to_phone** | optional | string | Optional test recipient number retained for existing assets; connectivity validation does not send SMS messages. |
 
 ### Supported Actions
 

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* - Fixed test connectivity to validate Twilio account access without sending an SMS message.
+* Fixed test connectivity to validate Twilio account access without sending an SMS message.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* - Chore: Update development tooling.
+* - Fixed test connectivity to validate Twilio account access without sending an SMS message.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* - Chore: Update development tooling.

--- a/twilio.json
+++ b/twilio.json
@@ -48,7 +48,7 @@
             "order": 3
         },
         "to_phone": {
-            "description": "To Phone Number (Used only for test connectivity)",
+            "description": "Optional test recipient number retained for existing assets; connectivity validation does not send SMS messages.",
             "data_type": "string",
             "order": 4
         }

--- a/twilio_connector.py
+++ b/twilio_connector.py
@@ -153,7 +153,7 @@ class TwilioConnector(BaseConnector):
             self.save_progress("Connecting to the Twilio account to check connectivity")
 
             # make rest call
-            ret_val, response = self._make_rest_call(".json", action_result, method="get")
+            ret_val, _response = self._make_rest_call(".json", action_result, method="get")
 
             if phantom.is_fail(ret_val):
                 self.save_progress("Test Connectivity Failed")

--- a/twilio_connector.py
+++ b/twilio_connector.py
@@ -47,7 +47,6 @@ class TwilioConnector(BaseConnector):
         self._from_phone = None
         self._account_sid = None
         self._auth_token = None
-        self._to_phone = None
 
         return
 
@@ -149,24 +148,13 @@ class TwilioConnector(BaseConnector):
     def _handle_test_connectivity(self, param):
         action_result = self.add_action_result(ActionResult(dict(param)))
 
-        if self._to_phone is None:
-            self.save_progress("Connecting to the Twilio account to check connectivity")
+        self.save_progress("Connecting to the Twilio account to check connectivity")
 
-            # make rest call
-            ret_val, _response = self._make_rest_call(".json", action_result, method="get")
+        ret_val, _ = self._make_rest_call(".json", action_result, method="get")
 
-            if phantom.is_fail(ret_val):
-                self.save_progress("Test Connectivity Failed")
-                return action_result.get_status()
-
-        else:
-            self.save_progress("Sending a message to validate config")
-
-            ret_val, _ = self._send_text(action_result, "Testing connectivity from Phantom to Twilio", self._to_phone)
-
-            if phantom.is_fail(ret_val):
-                self.save_progress("Test connectivity Failed")
-                return action_result.get_status()
+        if phantom.is_fail(ret_val):
+            self.save_progress("Test Connectivity Failed")
+            return action_result.get_status()
 
         self.save_progress("Test connectivity Passed")
 
@@ -289,8 +277,6 @@ class TwilioConnector(BaseConnector):
 
         self._account_sid = config["account_sid"]
         self._auth_token = config["auth_token"]
-        self._to_phone = config.get("to_phone")
-
         return phantom.APP_SUCCESS
 
     def finalize(self):


### PR DESCRIPTION
## Summary

- Replaces the connectivity-test SMS path with the existing account-read validation.
- Retains existing `to_phone` asset settings without using them for connectivity checks.
- Refreshes pre-commit tooling through dev-cicd-tools v2.2.8 and djLint v1.42.1.

## Tracking

- PSAAS-32609
- PAPP-38324
- Provenance: VULN-95332, FS-4173
- Epic: ESPM-5228

## Validation

- Python 3.13 syntax compilation
- Full pre-commit suite, including Docker package-app-dependencies

Written by Codex.